### PR TITLE
Kafka. Fix bug creating new topics

### DIFF
--- a/kafka/v0.10.0.1/config/server.properties.template
+++ b/kafka/v0.10.0.1/config/server.properties.template
@@ -54,7 +54,7 @@ auto.leader.rebalance.enable=true
 ############################# Replication #############################
 
 # Default replication factors for automatically created topics
-default.replication.factor=3
+default.replication.factor=1
 
 ############################# Log Basics #############################
 


### PR DESCRIPTION
Kafka change default.replication.factor from 3 to 1 because the server only runs one replica

To fix error: `ERROR [KafkaApi-1] Error when handling request {topics=[testing]} (kafka.server.KafkaApis)
kafka.admin.AdminOperationException: replication factor: 3 larger than available brokers: 1`