### PR TITLE
go with librdkafka

### DIFF
--- a/.github/workflows/build-go-kafka-client-1.4.4.yaml
+++ b/.github/workflows/build-go-kafka-client-1.4.4.yaml
@@ -1,0 +1,26 @@
+name: docker-build-go-kafka-client-v1.4.4
+
+on:
+  push:
+    paths:
+      - "go-kafka-client/v1.4.4/**"
+      - '.github/workflows/build-go-kafka-client-1.4.4.yaml'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3.1.0
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          file: go-kafka-client/v1.4.4/Dockerfile
+          context: ./go-kafka-client/v1.4.4
+          push: true
+          tags: davidoram/go-kafka-client:1.4.4

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 Useful docker images, that run on `amd64` and `arm64` architectures:
 
+- [`go-kafka-client v1.4.4`](go-kafka-client/v1.4.4/Dockerfile), is a `golang` image that contains preinstalled with the [librdkafka](https://github.com/confluentinc/librdkafka) library `v1.4.4` which works with Kafka `v0.10.0.1`. Note - this is **not** a multi-architecture build because thats not posible with this old version of librdkafka, but it will run fine on am M1 Mac.
 - [`Jailer v15.1.3`](jailer/v15.1.3/Dockerfile) See [Jailer](https://github.com/Wisser/Jailer) for more details.  This image is built from the `Jailer` source code, and is not available on Docker Hub. It is built for `amd64` and `arm64` architectures. Jailer is installed in `/opt/jailer`, which is added to the `PATH` environment variable.
 - [`Kafka v0.10.0.1`](kafka/v0.10.0.1/Dockerfile)
 - [`Postgres v13.5`](postgres/v13.5/Dockerfile)

--- a/go-kafka-client/v1.4.4/Dockerfile
+++ b/go-kafka-client/v1.4.4/Dockerfile
@@ -1,0 +1,25 @@
+FROM golang:1.21.3-alpine AS builder
+
+WORKDIR /usr/src/app
+
+RUN apk add --no-cache openssh-client git gcc make bc musl-dev bash build-base openssl-dev zlib-dev sqlite
+RUN wget -O /usr/local/bin/wait-for-it.sh https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh && \
+    chmod +x /usr/local/bin/wait-for-it.sh
+
+ARG MIGRATE_VERSION=v4.16.2
+RUN go install -tags 'postgres' github.com/golang-migrate/migrate/v4/cmd/migrate@${MIGRATE_VERSION} && \
+    mv /go/bin/migrate /usr/local/bin/
+ARG LINTER_VERSION=v1.55.0
+RUN wget -O- -nv https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | \
+    sh -s ${LINTER_VERSION} && \
+    mv bin/golangci-lint /usr/local/bin/
+
+# Install librdkafka
+# If you change the version of librdkafka, search for it globally and update everywhere
+ARG LIBRDKAFKA_VER=1.4.4
+ENV LIBRDKAFKA_VER ${LIBRDKAFKA_VER}
+RUN wget -q -O - https://github.com/edenhill/librdkafka/archive/refs/tags/v${LIBRDKAFKA_VER}.tar.gz | tar xz
+RUN cd librdkafka-${LIBRDKAFKA_VER} && \
+    ./configure --install-deps && \
+    make && \
+    make install


### PR DESCRIPTION
[`go-kafka-client v1.4.4`](go-kafka-client/v1.4.4/Dockerfile), is a `golang` image that contains preinstalled with the [librdkafka](https://github.com/confluentinc/librdkafka) library `v1.4.4` which works with Kafka `v0.10.0.1`. Note - this is **not** a multi-architecture build because thats not posible with this old version of librdkafka, but it will run fine on am M1 Mac.